### PR TITLE
add vignette with case-crossover example

### DIFF
--- a/vignettes/case-crossover-example.Rmd
+++ b/vignettes/case-crossover-example.Rmd
@@ -1,0 +1,83 @@
+---
+title: "Case-Crossover Example"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Case-Crossover Example}
+  %\VignetteEncoding{UTF-8}
+  %\VignetteEngine{knitr::rmarkdown}
+editor_options: 
+  chunk_output_type: console
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(appc)
+library(dplyr, warn.conflicts = FALSE)
+```
+
+**update descriptions for cass-crossover throughout**
+
+This example details how to use the appc package to add air pollution exposure estimates for exact locations and dates defined by geocoded coordinates and a case date. For this example workflow, we will simulate 20 random locations in Wayne County, Michigan and case dates between 2019 and 2022, but in actuality this can be any set of geocoded `lat` and `lon` columns with corresponding dates.
+
+```{r}
+#| warnings: false
+#| messages: false
+d <-
+  tigris::counties("MI", year = 2021, progress_bar = FALSE) |>
+  suppressWarnings() |>
+  filter(GEOID == 26163) |>
+  sf::st_sample(20) |>
+  sf::st_coordinates() |>
+  tibble::as_tibble() |>
+  rename(lat = Y, lon = X) |>
+  mutate(case_date = sample(seq(as.Date("2019-01-01"), as.Date("2022-12-31"), by = 1), size = 20)) |>
+  mutate(id = 1:20) |>
+  relocate(id)
+
+d
+```
+
+For this example, we want to estimate the fine particulate matter on the days of the case, as well as control dates. Here, we define these control dates using time stratification on year, month, and day-of-week, and use the `purrr` package to create a list-col of dates for each location in our example data:
+
+```{r}
+dates_seq <- seq(min(d$case_date), max(d$case_date), by = 1)
+
+make_control_dates <- function(case_date) {
+  dates_seq[lubridate::year(dates_seq) == lubridate::year(case_date) & 
+            lubridate::month(dates_seq) == lubridate::month(case_date) & 
+            lubridate::wday(dates_seq) == lubridate::wday(case_date)]
+}
+
+d <- d |>
+  rowwise() |>
+  mutate(dates = purrr::map(case_date, make_control_dates)) |>
+  ungroup()
+
+d
+```
+
+Next, we will use the `lon` and `lat` columns to create the s2 geohash:
+
+```{r}
+d <- d |> dplyr::mutate(s2 = s2::as_s2_cell(s2::s2_geog_point(lon, lat)))
+
+d
+```
+
+Then we can directly use the `s2` and `dates` columns to add temperature and humidity using the `get_narr_data()` function and PM2.5 using the  `predict_pm25()` function:
+
+```{r}
+d <- d |> dplyr::mutate(temperature = get_narr_data(s2, dates, "air.2m"), 
+                        humidity = get_narr_data(s2, dates, "rhum.2m"))
+
+
+d <- d |> dplyr::mutate(pm25 = predict_pm25(s2, dates, quiet = FALSE))
+
+d
+```


### PR DESCRIPTION
- `predict_pm25()` not working (see #54)
- so far only case and control dates... do we want lag days? 
- more explanation/context for temp/humidity?
- wrote my own function to generate control dates... not sure if there is a better way